### PR TITLE
admin functionality

### DIFF
--- a/test/swivel/Swivel.sol
+++ b/test/swivel/Swivel.sol
@@ -387,4 +387,9 @@ contract Swivel {
     require(o.maker == Sig.recover(Hash.message(DOMAIN, Hash.order(o)), c), 'invalid signature');
     _;
   }
+
+  modifier onlyAdmin(address a) {
+    require(msg.sender == a, 'sender must be admin');
+    _;
+  }
 }

--- a/test/swivel/Swivel.sol
+++ b/test/swivel/Swivel.sol
@@ -63,7 +63,7 @@ contract Swivel {
   /// @notice Allows the admin to queue the withdrawal of arbitrary tokens
   /// @param e Address of token to withdraw
   function queueTokenWithdrawal(address e) external onlyAdmin(admin) {
-      queuedTimestamp[e] = block.timestamp;
+      queuedTimestamp[e] = block.timestamp + 259200;
       withdrawalQueue[e] = true;
       emit withdrawalQueued(e, (block.timestamp + 259200));
   }
@@ -77,26 +77,13 @@ contract Swivel {
   /// @notice Allows the admin to withdraw any arbitrary token
   /// @param e Address of token to withdraw
   function withdrawTokens(address e) external onlyAdmin(admin) {
-      require (block.timestamp - queuedTimestamp[e] > 259200, "withdrawal currently timelocked");
+      require (block.timestamp >= queuedTimestamp[e], "withdrawal currently timelocked");
       require (withdrawalQueue[e], "withdrawal not queued");
       
       withdrawalQueue[e] = false;
       Erc20 token = Erc20(e);
       uint256 amount = token.balanceOf(address(this));
       token.transfer(admin,amount);
-  }
-  
-  /// @notice Allows the current admin to transfer admin powers to another address
-  /// @param t Address of the new admin
-  function transferAdmin(address t) external onlyAdmin(admin) {
-      previousAdmin = admin;
-      admin = t;
-  }
-  
-  /// @notice Emergency function to recover admin (Seems pointless, but in a bundle can block malicious token withdrawals)
-  function recoverAdmin() external {
-      require (msg.sender == previousAdmin, "must be the previous admin");
-      admin = previousAdmin;
   }
   
 


### PR DESCRIPTION
Added admin functionality to swivel.sol in order to be able to handle erc-20 token rewards and fees which may be accrued to swivel.sol's address.

**Withdrawal Happy Path:**
1. Queue withdrawal for a given token
2. Withdraw to admin address after withdraw timelock passes (3 days)

**Swivel admin is somehow vulnerable / transferred to malicious party path:**
1. Admin transferred to malicious party
2. Malicious withdrawal queued
3. Admin recovered by previous admin
4. Withdrawal blocked

**Swivel admin is malicious path:**
1. Malicious admin multisig queues withdrawal
2. Users have 3 days to withdraw their funds


- Admin set in constructor
- Withdrawals are queued and timelocked
- Withdrawals can be blocked by admin
- Admin can transfer admin privileges
- Admin can recover admin and queue withdrawal should privileges be maliciously transferred