### PR TITLE
fee-implementation

### DIFF
--- a/test/marketplace/MarketPlace.sol
+++ b/test/marketplace/MarketPlace.sol
@@ -253,6 +253,16 @@ contract MarketPlace {
     emit TransferVaultNotional(u, m, msg.sender, t, a);
     return true;
   }
+  /// @notice transfers notional fee to the Swivel contract without recalculating marginal interest for from
+  /// @param u Underlying token address associated with the market
+  /// @param m Maturity timestamp of the market
+  /// @param f Owner of the amount
+  /// @param t Address of swivel.sol
+  /// @param a Amount to transfer
+  function transferVaultNotionalFee(address u, uint256 m, address f, address t, uint256 a) public onlySwivel(swivel) returns (bool) {
+    VaultTracker(markets[u][m].vaultAddr).transferNotionalFee(f, t, a);
+    return true;
+  }
 
   modifier onlyAdmin(address a) {
     require(msg.sender == a, 'sender must be admin');

--- a/test/swivel/Abstracts.sol
+++ b/test/swivel/Abstracts.sol
@@ -17,10 +17,11 @@ abstract contract CErc20 is Erc20 {
 }
 
 abstract contract MarketPlace {
-  //adds notional and mints zctokens to msg.sender
+  // adds notional and mints zctokens
   function mintZcTokenAddingNotional(address, uint256, address, uint256) virtual external returns (bool);
-  //removes notional and burns zctokens from msg.sender
+  // removes notional and burns zctokens
   function burnZcTokenRemovingNotional(address, uint256, address, uint256) virtual external returns (bool);
+  // returns cTokenAddress for a given market
   function cTokenAddress(address, uint256) virtual external returns (address);
   // EVFZE FF EZFVE call this which would then burn zctoken and remove notional
   function custodialExit(address, uint256, address, address, uint256) virtual external returns (bool);
@@ -30,4 +31,6 @@ abstract contract MarketPlace {
   function p2pZcTokenExchange(address, uint256, address, address, uint256) virtual external returns (bool);
   // IVFVE && EVFVI call this, removing notional from one party and adding to the other
   function p2pVaultExchange(address, uint256, address, address, uint256) virtual external returns (bool);
+  // IVFZI && IVFVE call this which then transfers notional from msg.sender (taker) to swivel
+  function transferVaultNotionalFee(address, uint256, address, address, uint256) virtual external returns (bool);
 }

--- a/test/swivel/Swivel.sol
+++ b/test/swivel/Swivel.sol
@@ -35,6 +35,7 @@ contract Swivel {
     DOMAIN = Hash.domain(NAME, VERSION, block.chainid, address(this));
     marketPlace = m;
     admin = msg.sender;
+    feeDenominator = 400;
   }
 
 

--- a/test/swivel/Swivel.sol
+++ b/test/swivel/Swivel.sol
@@ -119,7 +119,7 @@ contract Swivel {
 
     Erc20 uToken = Erc20(o.underlying);
     uint256 premiumFilled = (((a * 1e18) / o.principal) * o.premium) / 1e18;
-    uint256 fee = ((premiumFilled * 1e18) / feeDenominator) / 1e18;
+    uint256 fee = ((premiumFilled * 1e18) / (feeDenominator/2)) / 1e18;
     
     uToken.transferFrom(o.maker, msg.sender, premiumFilled);
     uToken.transferFrom(msg.sender, address(this), a);
@@ -151,7 +151,7 @@ contract Swivel {
     
     Erc20 uToken = Erc20(o.underlying);
     uint256 premiumFilled = (((a * 1e18) / o.principal) * o.premium) / 1e18;
-    uint256 fee = ((premiumFilled * 1e18) / feeDenominator) / 1e18;
+    uint256 fee = ((premiumFilled * 1e18) / (feeDenominator/2)) / 1e18;
     
     uToken.transferFrom(msg.sender, o.maker, (a - premiumFilled));
     // notify the marketplace...
@@ -258,7 +258,7 @@ contract Swivel {
     
     Erc20 uToken = Erc20(o.underlying);
     uint256 premiumFilled = (((a * 1e18) / o.principal) * o.premium) / 1e18;
-    uint256 fee = ((premiumFilled * 1e18) / feeDenominator) / 1e18;
+    uint256 fee = ((premiumFilled * 1e18) / (feeDenominator/2)) / 1e18;
 
     // transfer premium from o.maker to msg.sender
     uToken.transferFrom(o.maker, msg.sender, premiumFilled-fee);
@@ -284,7 +284,7 @@ contract Swivel {
     
     Erc20 uToken = Erc20(o.underlying);
     uint256 premiumFilled = (((a * 1e18) / o.principal) * o.premium) / 1e18;
-    uint256 fee = ((premiumFilled * 1e18) / feeDenominator) / 1e18;
+    uint256 fee = ((premiumFilled * 1e18) / (feeDenominator/2)) / 1e18;
     
     MarketPlace mPlace = MarketPlace(marketPlace);
     // alert MarketPlace...

--- a/test/swivel/Swivel.sol
+++ b/test/swivel/Swivel.sol
@@ -17,7 +17,11 @@ contract Swivel {
   bytes32 public immutable DOMAIN;
   address public immutable marketPlace;
   address public immutable admin;
-  uint256 public feeDenominator;
+  uint16[] public feeDenominator;
+  //0 = zcTokenInitiate Fee Denominator
+  //1 = zcTokenExit Fee Denominator
+  //2 = VaultInitiate Fee Denominator
+  //3 = VaultExit Fee Denominator
 
   /// @notice Emitted on order cancellation
   event Cancel (bytes32 indexed key);
@@ -35,16 +39,17 @@ contract Swivel {
     DOMAIN = Hash.domain(NAME, VERSION, block.chainid, address(this));
     marketPlace = m;
     admin = msg.sender;
-    feeDenominator = 400;
+    feeDenominator = [200,600,400,200];
   }
 
 
   // ********* ADMIN FUNCTIONS *************
 
   // @notice Allows the admin to set a new fee denominator
+  // @param t The type of order 
   // @param f The new fee denominator
-  function setFee(uint256 d) external onlyAdmin(admin) {
-      feeDenominator = d;
+  function setFee(uint8 t, uint16 d) external onlyAdmin(admin) {
+      feeDenominator[t] = d;
   }
 
   // ********* INITIATING *************
@@ -87,7 +92,7 @@ contract Swivel {
     
     Erc20 uToken = Erc20(o.underlying);
     uint256 principalFilled = (((a * 1e18) / o.premium) * o.principal) / 1e18;
-    uint256 fee = ((principalFilled * 1e18) / feeDenominator) / 1e18;
+    uint256 fee = ((principalFilled * 1e18) / feeDenominator[2]) / 1e18;
     
     uToken.transferFrom(msg.sender, o.maker, a);
     uToken.transferFrom(o.maker, address(this), principalFilled);
@@ -119,7 +124,7 @@ contract Swivel {
 
     Erc20 uToken = Erc20(o.underlying);
     uint256 premiumFilled = (((a * 1e18) / o.principal) * o.premium) / 1e18;
-    uint256 fee = ((premiumFilled * 1e18) / (feeDenominator/2)) / 1e18;
+    uint256 fee = ((premiumFilled * 1e18) / feeDenominator[0]) / 1e18;
     
     uToken.transferFrom(o.maker, msg.sender, premiumFilled);
     uToken.transferFrom(msg.sender, address(this), a);
@@ -151,7 +156,7 @@ contract Swivel {
     
     Erc20 uToken = Erc20(o.underlying);
     uint256 premiumFilled = (((a * 1e18) / o.principal) * o.premium) / 1e18;
-    uint256 fee = ((premiumFilled * 1e18) / (feeDenominator/2)) / 1e18;
+    uint256 fee = ((premiumFilled * 1e18) / feeDenominator[0]) / 1e18;
     
     uToken.transferFrom(msg.sender, o.maker, (a - premiumFilled));
     // notify the marketplace...
@@ -174,7 +179,7 @@ contract Swivel {
     filled[o.key] += a;
     
     uint256 principalFilled = (((a * 1e18) / o.premium) * o.principal) / 1e18;
-    uint256 fee = ((principalFilled * 1e18) / feeDenominator) / 1e18;
+    uint256 fee = ((principalFilled * 1e18) / feeDenominator[2]) / 1e18;
 
     MarketPlace mPlace = MarketPlace(marketPlace);
 
@@ -233,7 +238,7 @@ contract Swivel {
     
     Erc20 uToken = Erc20(o.underlying);
     uint256 principalFilled = (((a * 1e18) / o.premium) * o.principal) / 1e18;
-    uint256 fee = ((principalFilled * 1e18) / feeDenominator) / 1e18;
+    uint256 fee = ((principalFilled * 1e18) / feeDenominator[1]) / 1e18;
     
     // transfer underlying from initiating party to exiting party, minus the price the exit party pays for the exit (interest), and the fee.
     uToken.transferFrom(o.maker, msg.sender, (principalFilled - a - fee));
@@ -258,7 +263,7 @@ contract Swivel {
     
     Erc20 uToken = Erc20(o.underlying);
     uint256 premiumFilled = (((a * 1e18) / o.principal) * o.premium) / 1e18;
-    uint256 fee = ((premiumFilled * 1e18) / (feeDenominator/2)) / 1e18;
+    uint256 fee = ((premiumFilled * 1e18) / feeDenominator[3]) / 1e18;
 
     // transfer premium from o.maker to msg.sender
     uToken.transferFrom(o.maker, msg.sender, premiumFilled-fee);
@@ -284,7 +289,7 @@ contract Swivel {
     
     Erc20 uToken = Erc20(o.underlying);
     uint256 premiumFilled = (((a * 1e18) / o.principal) * o.premium) / 1e18;
-    uint256 fee = ((premiumFilled * 1e18) / (feeDenominator/2)) / 1e18;
+    uint256 fee = ((premiumFilled * 1e18) / feeDenominator[3]) / 1e18;
     
     MarketPlace mPlace = MarketPlace(marketPlace);
     // alert MarketPlace...
@@ -316,7 +321,7 @@ contract Swivel {
 
     Erc20 uToken = Erc20(o.underlying);
     uint256 principalFilled = (((a * 1e18) / o.premium) * o.principal) / 1e18;
-    uint256 fee = ((principalFilled * 1e18) / feeDenominator) / 1e18;
+    uint256 fee = ((principalFilled * 1e18) / feeDenominator[1]) / 1e18;
     
     MarketPlace mPlace = MarketPlace(marketPlace);
     // alert MarketPlace...


### PR DESCRIPTION
This is a feature that is a bit of a moving target. We might want to implement an addition that allows the admin mulitsig to change the fee %, which I will consider adding to this PR.


Overall, the goal is to place a fee on the output of takers, currently .25% across the board.
zcToken Initiates -- .25% of their premium amount received. (e.g. 1000 principal, 50 premium, .25% of 50 = .125)
zcToken Exits -- .25% of their underlying exit amount received. (e.g. 1000 principal, 50 premium, 1000-50 = 950, .25% of 950 = 2.375)
Vault Initiates -- .25% of their notional amount received. (e.g. 1000 principal, 50 premium, .25% of 1000 = 2.5 notional)
Vault Exit -- .25% of their premium amount received. (e.g. 1000 principal, 50 premium, .25% of 50 = .125)




- Fee calculated within each function alongside premium/principalFilled calculation
- Fee transferred at bottom of every function
- For fees in vault notional, new functions implemented:
  - Passthrough function from Marketplace -> VaultTracker
  - VaultTracker function that transfers without resetting msg.sender's vault calculations (they were just calculated before the fee payment)