### PR TITLE
decimals-parameter

### DIFF
--- a/test/marketplace/MarketPlace.sol
+++ b/test/marketplace/MarketPlace.sol
@@ -48,17 +48,19 @@ contract MarketPlace {
   /// @param u Underlying token address associated with the new market
   /// @param m Maturity timestamp of the new market
   /// @param c cToken address associated with underlying for the new market
+  /// @param d Number of decimals the underlying token supports
   /// @param n Name of the new zcToken market
   /// @param s Symbol of the new zcToken market
   function createMarket(
     address u,
     uint256 m,
     address c,
+    uint256 d,
     string memory n,
     string memory s
   ) public onlyAdmin(admin) returns (bool) {
     // TODO can we live with the factory pattern here both bytecode size wise and CREATE opcode cost wise?
-    address zctAddr = address(new ZcToken(u, m, n, s));
+    address zctAddr = address(new ZcToken(u, m, d, n, s));
     address vAddr = address(new VaultTracker(m, c));
     markets[u][m] = Market(c, zctAddr, vAddr);
 

--- a/test/marketplace/MarketPlace.sol
+++ b/test/marketplace/MarketPlace.sol
@@ -55,7 +55,7 @@ contract MarketPlace {
     address u,
     uint256 m,
     address c,
-    uint256 d,
+    uint16 d,
     string memory n,
     string memory s
   ) public onlyAdmin(admin) returns (bool) {

--- a/test/marketplace/MarketPlace.sol
+++ b/test/marketplace/MarketPlace.sol
@@ -55,7 +55,7 @@ contract MarketPlace {
     address u,
     uint256 m,
     address c,
-    uint16 d,
+    uint8 d,
     string memory n,
     string memory s
   ) public onlyAdmin(admin) returns (bool) {

--- a/test/tokens/Erc2612.sol
+++ b/test/tokens/Erc2612.sol
@@ -24,7 +24,7 @@ contract Erc2612 is PErc20, IErc2612 {
   /// @param d number of decimals for the token
   /// @param n name for the token
   /// @param s symbol for the token
-  constructor(uint16 d, string memory n, string memory s) PErc20(d, n, s) {
+  constructor(uint8 d, string memory n, string memory s) PErc20(d, n, s) {
     DOMAIN = Hash.domain(n, '1', block.chainid, address(this));
   }
 

--- a/test/tokens/Erc2612.sol
+++ b/test/tokens/Erc2612.sol
@@ -21,9 +21,10 @@ contract Erc2612 is PErc20, IErc2612 {
 
   bytes32 public immutable DOMAIN;
 
+  /// @param d number of decimals for the token
   /// @param n name for the token
   /// @param s symbol for the token
-  constructor(string memory n, string memory s) PErc20(n, s) {
+  constructor(uint16 d, string memory n, string memory s) PErc20(d, n, s) {
     DOMAIN = Hash.domain(n, '1', block.chainid, address(this));
   }
 

--- a/test/tokens/PErc20.sol
+++ b/test/tokens/PErc20.sol
@@ -48,11 +48,13 @@ contract PErc20 is IPErc20 {
     mapping (address => mapping (address => uint256)) private allowances;
 
     uint256 public totalSupply;
+    uint16 public immutable decimals;
     string public name; // NOTE: cannot make strings immutable
     string public symbol; // NOTE: see above
 
     /**
      * @dev Sets the values for {name} and {symbol}.
+     * @dev d Number of decimals for the token
      * @param n Name of the token
      * @param s Symbol of the token
      *
@@ -62,26 +64,10 @@ contract PErc20 is IPErc20 {
      * All two of these values are immutable: they can only be set once during
      * construction.
      */
-    constructor (string memory n, string memory s) {
+    constructor (uint16 d, string memory n, string memory s) {
         name = n;
         symbol = s;
-    }
-
-    /**
-     * @dev Returns the number of decimals used to get its user representation.
-     * For example, if `decimals` equals `2`, a balance of `505` tokens should
-     * be displayed to a user as `5,05` (`505 / 10 ** 2`).
-     *
-     * Tokens usually opt for a value of 18, imitating the relationship between
-     * Ether and Wei. This is the value {ERC20} uses, unless this function is
-     * overridden;
-     *
-     * NOTE: This information is only used for _display_ purposes: it in
-     * no way affects any of the arithmetic of the contract, including
-     * {IERC20-balanceOf} and {IERC20-transfer}.
-     */
-    function decimals() public view virtual returns (uint8) {
-        return 18;
+        decimals = d;
     }
 
     /**

--- a/test/tokens/PErc20.sol
+++ b/test/tokens/PErc20.sol
@@ -48,7 +48,7 @@ contract PErc20 is IPErc20 {
     mapping (address => mapping (address => uint256)) private allowances;
 
     uint256 public totalSupply;
-    uint16 public decimals;
+    uint8 public decimals;
     string public name; // NOTE: cannot make strings immutable
     string public symbol; // NOTE: see above
 
@@ -64,7 +64,7 @@ contract PErc20 is IPErc20 {
      * All two of these values are immutable: they can only be set once during
      * construction.
      */
-    constructor (uint16 d, string memory n, string memory s) {
+    constructor (uint8 d, string memory n, string memory s) {
         name = n;
         symbol = s;
         decimals = d;

--- a/test/tokens/PErc20.sol
+++ b/test/tokens/PErc20.sol
@@ -48,7 +48,7 @@ contract PErc20 is IPErc20 {
     mapping (address => mapping (address => uint256)) private allowances;
 
     uint256 public totalSupply;
-    uint16 public immutable decimals;
+    uint16 public decimals;
     string public name; // NOTE: cannot make strings immutable
     string public symbol; // NOTE: see above
 

--- a/test/tokens/ZcToken.sol
+++ b/test/tokens/ZcToken.sol
@@ -20,7 +20,7 @@ contract ZcToken is Erc2612, IZcToken {
   /// @param d Decimals
   /// @param n Name
   /// @param s Symbol
-  constructor(address u, uint256 m, uint16 d, string memory n, string memory s) Erc2612(d, n, s) {
+  constructor(address u, uint256 m, uint8 d, string memory n, string memory s) Erc2612(d, n, s) {
     admin = msg.sender;  
     underlying = u;
     maturity = m;

--- a/test/tokens/ZcToken.sol
+++ b/test/tokens/ZcToken.sol
@@ -11,15 +11,16 @@ import './IZcToken.sol';
 /// NOTE the OZStlye naming conventions are kept for the internal methods
 /// _burn and _mint as dangling underscores are generally not allowed.
 contract ZcToken is Erc2612, IZcToken {
-  address public immutable  admin;
+  address public immutable admin;
   address public immutable underlying;
   uint256 public immutable maturity;
 
   /// @param u Underlying
   /// @param m Maturity
+  /// @param d Decimals
   /// @param n Name
   /// @param s Symbol
-  constructor(address u, uint256 m, string memory n, string memory s) Erc2612(n, s) {
+  constructor(address u, uint256 m, uint256 d, string memory n, string memory s) Erc2612(d, n, s) {
     admin = msg.sender;  
     underlying = u;
     maturity = m;

--- a/test/tokens/ZcToken.sol
+++ b/test/tokens/ZcToken.sol
@@ -20,7 +20,7 @@ contract ZcToken is Erc2612, IZcToken {
   /// @param d Decimals
   /// @param n Name
   /// @param s Symbol
-  constructor(address u, uint256 m, uint256 d, string memory n, string memory s) Erc2612(d, n, s) {
+  constructor(address u, uint256 m, uint16 d, string memory n, string memory s) Erc2612(d, n, s) {
     admin = msg.sender;  
     underlying = u;
     maturity = m;


### PR DESCRIPTION
#147 

We needed to account for the variable # of decimals in underlying tokens. We can do this by making sure our zcToken decimals mirror the underlying # of decimals.

**PERC:**
- Deleted explicit "Decimal" public getter that had hardcoded 18 decimal return.
- Add immutable "decimal" var, and which is set in constructor

**ERC2612/ZcToken:**
- Inherit / set decimal in constructor

**Marketplace:**
- Added decimals param to createMarket