### PR TITLE
add fee restriction

### DIFF
--- a/test/swivel/Swivel.sol
+++ b/test/swivel/Swivel.sol
@@ -414,6 +414,7 @@ contract Swivel {
   /// @param i The index of the new fee denominator
   /// @param d The new fee denominator
   function setFee(uint16 i, uint16 d) external authorized(admin) returns (bool) {
+    require(d >= 33, 'fee is too high');
     feenominators[i] = d;
 
     emit SetFee(i, d);


### PR DESCRIPTION
I went through all the input validation tickets: https://github.com/code-423n4/2021-09-swivel-findings/issues?q=is%3Aissue+validation

Just a 1 liner, the only one remaining was the fee. We've limited it at ~3%.