### PR TITLE
mock: yield token functionality

### DIFF
--- a/test/mocks/YieldToken.sol
+++ b/test/mocks/YieldToken.sol
@@ -1,0 +1,47 @@
+// SPDX-License-Identifier: UNLICENSED
+
+pragma solidity 0.8.13;
+
+interface IErc20 {
+	function approve(address, uint256) external returns (bool);
+	function transfer(address, uint256) external returns (bool);
+	function balanceOf(address) external returns (uint256);
+	function transferFrom(address, address, uint256) external returns (bool);
+}
+
+contract YieldToken {
+    uint32 private maturityReturn;
+    IErc20 private baseReturn;
+    uint128 private sellBaseReturn;
+    uint128 private sellBasePreviewReturn;
+
+    // mapping of arguments sent to sellBase. key is the passed in address.
+    mapping (address => uint256) public sellBaseCalled;
+    uint128 public sellBasePreviewCalled;
+
+    function base() external view returns (IErc20) {
+        return baseReturn;
+    }
+
+    function maturity() external view returns (uint32) {
+        return maturityReturn;
+    }
+
+    function sellBaseReturns(uint128 r) external {
+        sellBaseReturn = r;
+    }
+
+    function sellBasePreviewReturns(uint128 r) external {
+        sellBasePreviewReturn = r;
+    }
+
+    function sellBase(address a, uint128 u) external returns (uint128) {
+        sellBaseCalled[a] = u;
+        return sellBaseReturn;
+    }
+
+    function sellBasePreview(uint128 u) external returns (uint128) {
+        sellBasePreviewCalled = u;
+        return sellBasePreviewReturn;
+    }
+}


### PR DESCRIPTION
This PR implements a mocked `YieldToken`. It implements the `IYieldToken` defined in `interfaces.go`:

```solidity
interface IYieldToken {
  function base() external returns (IErc20); // TODO can we use the wide Interface here?
  function maturity() external returns (uint32);
  function sellBase(address, uint128) external returns (uint128);
  function sellBasePreview(uint128) external returns (uint128);
}
```